### PR TITLE
Sample Added: Notify with constantly ByteArray

### DIFF
--- a/SmartContract/NotifyWithByteArray.cs
+++ b/SmartContract/NotifyWithByteArray.cs
@@ -1,0 +1,34 @@
+﻿using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Services.Neo;
+using System;
+using System.Numerics;
+
+namespace NeoContract1
+{
+    /**
+        Snippet: Notify With Constantly ByteArray
+        
+    */
+    public class Contract1 : SmartContract
+    {
+
+		public static void Main()
+        {
+            byte[] empty = new byte[0];
+            
+            for (int i = 186; i >= 184; i -= 1)
+            {
+                BigInteger b0 = i;
+
+                byte[] ba = empty.Concat(b0.AsByteArray());
+				/** If using "byte[] ba = b0.AsByteArray();", it may no-yet-deterministically be convert to Integer in Runtime.Notify. 
+				     Replace the above line with the following one for test
+				*/
+
+				//byte[] ba = empty.Concat(b0.AsByteArray());
+
+                Runtime.Notify(ba);
+            }
+        }
+    }
+}


### PR DESCRIPTION
ByteArray sometimes automatically converted to Integer in Runtime.Notify. Concat it by an empty byte[] can resolve this problem. Here is the snippet.